### PR TITLE
Added a CircleCI configuration file to get continuous deployments to AWS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,62 @@
+# Javascript Node CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-javascript/ for more details
+#
+version: 2
+
+jobs:
+  build:
+    docker:
+      - image: circleci/node:8.1.4
+
+    steps:
+      - checkout
+
+      - run:
+          name: Install awscli, doesn't come by default with the node:8.1.4 image
+          # Python 2.7 comes by default with the Ubuntu container CircleCI uses.
+          # However it doesn't comes with python-dev which is required for installing pip. If not
+          # installed there will be an error when installing some package called "wheel". The
+          # next two commands fetches the pip install script and installs pip. After installing
+          # pip we add pip to the path (so we can subsequently use the command "pip"). This is
+          # required because awscli has other dependencies which requires the existence of pip on
+          # the path. Finally we install awscli.
+          #
+          # It should be noted this is a pretty ugly hack to get awscli in a Node container. In
+          # CircleCI v1 the images came by default with awscli, so this mess wasn't required.
+          command: |
+              sudo apt-get install python-dev
+              curl -O https://bootstrap.pypa.io/get-pip.py
+              python get-pip.py --user
+              export PATH=~/.local/bin:$PATH
+              pip install awscli --upgrade --user
+
+      - run:
+          name: Install Node dependencies with Yarn
+          command: yarn install
+
+      - run:
+          name: Build site, i.e. generate the build/ folder
+          command: yarn run build
+
+      - deploy:
+          name: Deploy site to AWS S3 and invalidate CloudFront cache
+          # If the branch is master we push the contents of the build/ folder to the
+          # xinqi-li.com bucket on AWS S3. The --delete flag means we delete files in the S3
+          # buckets if they don't exist in the build/ folder.
+          #
+          # Apparently each CircleCI step is run in a separate terminal session. That means that
+          # the command aws that we put on the path in the awscli installation step is not on the
+          # path. As a workaround I just call it directly from its full location: ~/.local/bin/aws
+          #
+          # After the S3 bucket has been updated with the new content we invalidate the CloudFront
+          # distributions (the thing that caches the static assets all over the world).
+          #
+          # $CLOUDFRONTDISTRIBUTIONID is an environment variable defined at circleci.com.
+          command: |
+            if [ "${CIRCLE_BRANCH}" == "master" ]; then
+                ~/.local/bin/aws s3 sync build/ s3://xinqi-li.com/ --delete
+                ~/.local/bin/aws cloudfront create-invalidation --distribution-id $CLOUDFRONTDISTRIBUTIONID --paths '/*'
+            else
+                echo "Not on master branch so not deploying"
+            fi


### PR DESCRIPTION
This CircleCI configuration is modified from the config I use on my personal sites jonrh.is and bespokedashboards.com. This config alone is not enough. We will have to define the $CLOUDFRONTDISTRIBUTIONID environment variable on the CircleCI website for the project. Furthermore we will have to create the apropriet AWS access roles so CircleCI has permissions to do what it needs to do.